### PR TITLE
Add fix for calc_ionograms in batch mode

### DIFF
--- a/calc_ionograms.py
+++ b/calc_ionograms.py
@@ -443,6 +443,7 @@ if __name__ == "__main__":
                 time.sleep(1)
         
     else: # batch analyze
+	d=drf.DigitalRFReader(conf.data_dir)
         analyze_all(conf,d)
 
 


### PR DESCRIPTION
Running calc_ionograms.py in batch mode is currently broken.

This one-line PR fixes that, and resolves issue: https://github.com/jvierine/chirpsounder2/issues/4

